### PR TITLE
compiling the improved skinning

### DIFF
--- a/interface/src/ui/AvatarInputs.cpp
+++ b/interface/src/ui/AvatarInputs.cpp
@@ -46,7 +46,7 @@ AvatarInputs::AvatarInputs(QQuickItem* parent) :  QQuickItem(parent) {
 #define AI_UPDATE_FLOAT(name, src, epsilon) \
     { \
         float val = src; \
-        if (fabs(_##name - val) >= epsilon) { \
+        if (fabsf(_##name - val) >= epsilon) { \
             _##name = val; \
             emit name##Changed(); \
         } \
@@ -82,7 +82,7 @@ void AvatarInputs::update() {
     if (audioLevel > 1.0f) {
         audioLevel = 1.0;
     }
-    AI_UPDATE_FLOAT(audioLevel, audioLevel, 0.01);
+    AI_UPDATE_FLOAT(audioLevel, audioLevel, 0.01f);
     AI_UPDATE(audioClipping, ((audioIO->getTimeSinceLastClip() > 0.0f) && (audioIO->getTimeSinceLastClip() < 1.0f)));
     AI_UPDATE(audioMuted, audioIO->isMuted());
 

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -1043,7 +1043,7 @@ void EntityTreeRenderer::playEntityCollisionSound(EntityItemPointer entity, cons
 
     // Shift the pitch down by ln(1 + (size / COLLISION_SIZE_FOR_STANDARD_PITCH)) / ln(2)
     const float COLLISION_SIZE_FOR_STANDARD_PITCH = 0.2f;
-    const float stretchFactor = log(1.0f + (minAACube.getLargestDimension() / COLLISION_SIZE_FOR_STANDARD_PITCH)) / log(2);
+    const float stretchFactor = logf(1.0f + (minAACube.getLargestDimension() / COLLISION_SIZE_FOR_STANDARD_PITCH)) / logf(2.0f);
     AudioInjector::playSound(collisionSound, volume, stretchFactor, collision.contactPoint);
 }
 

--- a/libraries/fbx/src/FBXReader.h
+++ b/libraries/fbx/src/FBXReader.h
@@ -219,8 +219,6 @@ public:
     Extents meshExtents;
     glm::mat4 modelTransform;
 
-    bool isEye;
-    
     QVector<FBXBlendshape> blendshapes;
 
     unsigned int meshIndex; // the order the meshes appeared in the object file

--- a/libraries/fbx/src/FBXReader.h
+++ b/libraries/fbx/src/FBXReader.h
@@ -202,7 +202,7 @@ public:
 /// A single mesh (with optional blendshapes) extracted from an FBX document.
 class FBXMesh {
 public:
-    
+
     QVector<FBXMeshPart> parts;
     
     QVector<glm::vec3> vertices;
@@ -211,9 +211,9 @@ public:
     QVector<glm::vec3> colors;
     QVector<glm::vec2> texCoords;
     QVector<glm::vec2> texCoords1;
-    QVector<glm::vec4> clusterIndices;
-    QVector<glm::vec4> clusterWeights;
-    
+    QVector<uint16_t> clusterIndices;
+    QVector<uint8_t> clusterWeights;
+
     QVector<FBXCluster> clusters;
 
     Extents meshExtents;

--- a/libraries/fbx/src/FBXReader_Mesh.cpp
+++ b/libraries/fbx/src/FBXReader_Mesh.cpp
@@ -422,17 +422,12 @@ void FBXReader::buildModelMesh(FBXMesh& extractedMesh, const QString& url) {
     int colorsSize = fbxMesh.colors.size() * sizeof(glm::vec3);
     int texCoordsSize = fbxMesh.texCoords.size() * sizeof(glm::vec2);
     int texCoords1Size = fbxMesh.texCoords1.size() * sizeof(glm::vec2);
-#define UNFORTUNATE_HACK
-#ifdef UNFORTUNATE_HACK
-    // HACK: store clusterIndices in floats rather than short integers
-    int clusterIndicesSize = fbxMesh.clusterIndices.size() * sizeof(float);
-#else // UNFORTUNATE_HACK
+
     int clusterIndicesSize = fbxMesh.clusterIndices.size() * sizeof(uint8_t);
     if (fbxMesh.clusters.size() > UINT8_MAX) {
         // we need 16 bits instead of just 8 for clusterIndices
         clusterIndicesSize *= 2;
     }
-#endif // UNFORTUNATE_HACK
     int clusterWeightsSize = fbxMesh.clusterWeights.size() * sizeof(uint8_t);
 
     int normalsOffset = 0;
@@ -452,17 +447,7 @@ void FBXReader::buildModelMesh(FBXMesh& extractedMesh, const QString& url) {
     attribBuffer->setSubData(colorsOffset, colorsSize, (gpu::Byte*) fbxMesh.colors.constData());
     attribBuffer->setSubData(texCoordsOffset, texCoordsSize, (gpu::Byte*) fbxMesh.texCoords.constData());
     attribBuffer->setSubData(texCoords1Offset, texCoords1Size, (gpu::Byte*) fbxMesh.texCoords1.constData());
-#ifdef UNFORTUNATE_HACK
-    // HACK: copy clusterIndices back into floats to appease render pipeline
-    QVector<float> clusterIndices;
-    int32_t numIndices = fbxMesh.clusterIndices.size();
-    clusterIndices.resize(numIndices);
-    for (int32_t i = 0; i < numIndices; ++i) {
-        assert(fbxMesh.clusterIndices[i] <= UINT8_MAX);
-        clusterIndices[i] = (float)(fbxMesh.clusterIndices[i]);
-    }
-    attribBuffer->setSubData(clusterIndicesOffset, clusterIndicesSize, (gpu::Byte*) clusterIndices.constData());
-#else // UNFORTUNATE_HACK
+
     if (fbxMesh.clusters.size() < UINT8_MAX) {
         // yay! we can fit the clusterIndices within 8-bits
         int32_t numIndices = fbxMesh.clusterIndices.size();
@@ -476,7 +461,6 @@ void FBXReader::buildModelMesh(FBXMesh& extractedMesh, const QString& url) {
     } else {
         attribBuffer->setSubData(clusterIndicesOffset, clusterIndicesSize, (gpu::Byte*) fbxMesh.clusterIndices.constData());
     }
-#endif // UNFORTUNATE_HACK
     attribBuffer->setSubData(clusterWeightsOffset, clusterWeightsSize, (gpu::Byte*) fbxMesh.clusterWeights.constData());
 
     if (normalsSize) {
@@ -509,14 +493,6 @@ void FBXReader::buildModelMesh(FBXMesh& extractedMesh, const QString& url) {
                             gpu::Element(gpu::VEC2, gpu::FLOAT, gpu::UV)));
     }
 
-#ifdef UNFORTUNATE_HACK
-    // HACK: cluster indices are submitted to render pipeline in FLOAT format
-    if (clusterIndicesSize) {
-        mesh->addAttribute(gpu::Stream::SKIN_CLUSTER_INDEX,
-                          model::BufferView(attribBuffer, clusterIndicesOffset, clusterIndicesSize,
-                                            gpu::Element(gpu::VEC4, gpu::FLOAT, gpu::XYZW)));
-    }
-#else // UNFORTUNATE_HACK
     if (clusterIndicesSize) {
         if (fbxMesh.clusters.size() < UINT8_MAX) {
             mesh->addAttribute(gpu::Stream::SKIN_CLUSTER_INDEX,
@@ -528,7 +504,6 @@ void FBXReader::buildModelMesh(FBXMesh& extractedMesh, const QString& url) {
                                                  gpu::Element(gpu::VEC4, gpu::UINT16, gpu::XYZW)));
         }
     }
-#endif // UNFORTUNATE_HACK
     if (clusterWeightsSize) {
         mesh->addAttribute(gpu::Stream::SKIN_CLUSTER_WEIGHT,
                           model::BufferView(attribBuffer, clusterWeightsOffset, clusterWeightsSize,

--- a/libraries/gpu-gl/src/gpu/gl41/GL41BackendInput.cpp
+++ b/libraries/gpu-gl/src/gpu/gl41/GL41BackendInput.cpp
@@ -99,8 +99,13 @@ void GL41Backend::updateInput() {
                             GLboolean isNormalized = attrib._element.isNormalized();
 
                             for (size_t locNum = 0; locNum < locationCount; ++locNum) {
-                                glVertexAttribPointer(slot + (GLuint)locNum, count, type, isNormalized, stride,
-                                    reinterpret_cast<GLvoid*>(pointer + perLocationStride * (GLuint)locNum));
+                                if (attrib._element.isInteger()) {
+                                    glVertexAttribIPointer(slot + (GLuint)locNum, count, type, stride,
+                                        reinterpret_cast<GLvoid*>(pointer + perLocationStride * (GLuint)locNum));
+                                } else {
+                                    glVertexAttribPointer(slot + (GLuint)locNum, count, type, isNormalized, stride,
+                                        reinterpret_cast<GLvoid*>(pointer + perLocationStride * (GLuint)locNum));
+                                }
 #ifdef GPU_STEREO_DRAWCALL_INSTANCED
                                 glVertexAttribDivisor(slot + (GLuint)locNum, attrib._frequency * (isStereo() ? 2 : 1));
 #else

--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendInput.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendInput.cpp
@@ -61,8 +61,11 @@ void GL45Backend::updateInput() {
                             _input._attributeActivation.set(attriNum);
                             glEnableVertexAttribArray(attriNum);
                         }
-                        glVertexAttribFormat(attriNum, count, type, isNormalized, offset + locNum * perLocationSize);
-                        // TODO: Support properly the IAttrib version
+                        if (attrib._element.isInteger()) {
+                            glVertexAttribIFormat(attriNum, count, type, offset + locNum * perLocationSize);
+                        } else {
+                            glVertexAttribFormat(attriNum, count, type, isNormalized, offset + locNum * perLocationSize);
+                        }
                         glVertexAttribBinding(attriNum, attrib._channel);
                     }
 

--- a/libraries/gpu/src/gpu/Format.h
+++ b/libraries/gpu/src/gpu/Format.h
@@ -75,12 +75,12 @@ static const bool TYPE_IS_INTEGER[NUM_TYPES] = {
     true,
 
     // Normalized values
-    true,
-    true,
-    true,
-    true,
-    true,
-    true
+    false,
+    false,
+    false,
+    false,
+    false,
+    false
 };
 
 // Dimension of an Element

--- a/libraries/gpu/src/gpu/Inputs.slh
+++ b/libraries/gpu/src/gpu/Inputs.slh
@@ -15,7 +15,7 @@ layout(location = 1) in vec4 inNormal;
 layout(location = 2) in vec4 inColor;
 layout(location = 3) in vec4 inTexCoord0;
 layout(location = 4) in vec4 inTangent;
-layout(location = 5) in vec4 inSkinClusterIndex;
+layout(location = 5) in ivec4 inSkinClusterIndex;
 layout(location = 6) in vec4 inSkinClusterWeight;
 layout(location = 7) in vec4 inTexCoord1;
 <@endif@>

--- a/libraries/render-utils/src/Skinning.slh
+++ b/libraries/render-utils/src/Skinning.slh
@@ -18,11 +18,11 @@ layout(std140) uniform skinClusterBuffer {
     mat4 clusterMatrices[MAX_CLUSTERS];
 };
 
-void skinPosition(vec4 skinClusterIndex, vec4 skinClusterWeight, vec4 inPosition, out vec4 skinnedPosition) {
+void skinPosition(ivec4 skinClusterIndex, vec4 skinClusterWeight, vec4 inPosition, out vec4 skinnedPosition) {
     vec4 newPosition = vec4(0.0, 0.0, 0.0, 0.0);
 
     for (int i = 0; i < INDICES_PER_VERTEX; i++) {
-        mat4 clusterMatrix = clusterMatrices[int(skinClusterIndex[i])];
+        mat4 clusterMatrix = clusterMatrices[(skinClusterIndex[i])];
         float clusterWeight = skinClusterWeight[i];
         newPosition += clusterMatrix * inPosition * clusterWeight;
     }
@@ -30,13 +30,13 @@ void skinPosition(vec4 skinClusterIndex, vec4 skinClusterWeight, vec4 inPosition
     skinnedPosition = newPosition;
 }
 
-void skinPositionNormal(vec4 skinClusterIndex, vec4 skinClusterWeight, vec4 inPosition, vec3 inNormal,
+void skinPositionNormal(ivec4 skinClusterIndex, vec4 skinClusterWeight, vec4 inPosition, vec3 inNormal,
                         out vec4 skinnedPosition, out vec3 skinnedNormal) {
     vec4 newPosition = vec4(0.0, 0.0, 0.0, 0.0);
     vec4 newNormal = vec4(0.0, 0.0, 0.0, 0.0);
 
     for (int i = 0; i < INDICES_PER_VERTEX; i++) {
-        mat4 clusterMatrix = clusterMatrices[int(skinClusterIndex[i])];
+        mat4 clusterMatrix = clusterMatrices[(skinClusterIndex[i])];
         float clusterWeight = skinClusterWeight[i];
         newPosition += clusterMatrix * inPosition * clusterWeight;
         newNormal += clusterMatrix * vec4(inNormal.xyz, 0.0) * clusterWeight;
@@ -46,14 +46,14 @@ void skinPositionNormal(vec4 skinClusterIndex, vec4 skinClusterWeight, vec4 inPo
     skinnedNormal = newNormal.xyz;
 }
 
-void skinPositionNormalTangent(vec4 skinClusterIndex, vec4 skinClusterWeight, vec4 inPosition, vec3 inNormal, vec3 inTangent,
+void skinPositionNormalTangent(ivec4 skinClusterIndex, vec4 skinClusterWeight, vec4 inPosition, vec3 inNormal, vec3 inTangent,
                                out vec4 skinnedPosition, out vec3 skinnedNormal, out vec3 skinnedTangent) {
     vec4 newPosition = vec4(0.0, 0.0, 0.0, 0.0);
     vec4 newNormal = vec4(0.0, 0.0, 0.0, 0.0);
     vec4 newTangent = vec4(0.0, 0.0, 0.0, 0.0);
 
     for (int i = 0; i < INDICES_PER_VERTEX; i++) {
-        mat4 clusterMatrix = clusterMatrices[int(skinClusterIndex[i])];
+        mat4 clusterMatrix = clusterMatrices[(skinClusterIndex[i])];
         float clusterWeight = skinClusterWeight[i];
         newPosition += clusterMatrix * inPosition * clusterWeight;
         newNormal += clusterMatrix * vec4(inNormal.xyz, 0.0) * clusterWeight;

--- a/libraries/ui/src/ui/Menu.cpp
+++ b/libraries/ui/src/ui/Menu.cpp
@@ -471,10 +471,10 @@ void Menu::removeSeparator(const QString& menuName, const QString& separatorName
         int textAt = findPositionOfMenuItem(menu, separatorName);
         QList<QAction*> menuActions = menu->actions();
         if (textAt > 0 && textAt < menuActions.size()) {
-            QAction* separatorText = menuActions[textAt];
             QAction* separatorLine = menuActions[textAt - 1];
             if (separatorLine) {
                 if (separatorLine->isSeparator()) {
+                    QAction* separatorText = menuActions[textAt];
                     menu->removeAction(separatorText);
                     menu->removeAction(separatorLine);
                     separatorRemoved = true;


### PR DESCRIPTION
Andrew, i have simply added the shader and remove the  fallback code path you put in defines and voila!
I tested on my home PC with both 4.1 and 4.5 backends with success
in dev-chris2 where we have the 100 avatars in zaru i get the following differences:

Buffer Memory [Mb]
Master: CPU=145    gpu=125
PR:        CPU=123    gpu=104

SO this is great, totally improve the mem consumption.
I would have to try on my i5 with the low end ati to eventually see a benefit on the actual execution time but i bet it helps.

I honestly don't know what is different with what you (we) tested on your linux box and it was not working. It could be that the shaders weren't actually updated as expected maybe.

Enjoy,

PS: i also pulled upstream master...