### PR TITLE
Render accuracy check in DiffTraversal cases

### DIFF
--- a/assignment-client/src/entities/EntityTreeSendThread.cpp
+++ b/assignment-client/src/entities/EntityTreeSendThread.cpp
@@ -170,7 +170,7 @@ bool EntityTreeSendThread::addDescendantsToExtraFlaggedEntities(const QUuid& fil
     return hasNewChild || hasNewDescendants;
 }
 
-void EntityTreeSendThread::startNewTraversal(const ViewFrustum& view, EntityTreeElementPointer root, float octreeSizeScale, int32_t lodLevelOffset) {
+void EntityTreeSendThread::startNewTraversal(const ViewFrustum& view, EntityTreeElementPointer root, int32_t lodLevelOffset) {
     DiffTraversal::Type type = _traversal.prepareNewTraversal(view, root, lodLevelOffset);
     // there are three types of traversal:
     //
@@ -199,7 +199,7 @@ void EntityTreeSendThread::startNewTraversal(const ViewFrustum& view, EntityTree
                         // before we consider including it.
                         float renderAccuracy = calculateRenderAccuracy(_traversal.getCurrentView().getPosition(),
                                                                        cube,
-                                                                       octreeSizeScale,
+                                                                       _traversal.getCurrentRootSizeScale(),
                                                                        lodLevelOffset);
 
                         // Only send entities if they are large enough to see
@@ -228,7 +228,7 @@ void EntityTreeSendThread::startNewTraversal(const ViewFrustum& view, EntityTree
                                 // See the DiffTraversal::First case for an explanation of the "entity is too small" check
                                 float renderAccuracy = calculateRenderAccuracy(_traversal.getCurrentView().getPosition(),
                                                                                cube,
-                                                                               octreeSizeScale,
+                                                                               _traversal.getCurrentRootSizeScale(),
                                                                                lodLevelOffset);
 
                                 // Only send entities if they are large enough to see
@@ -259,7 +259,7 @@ void EntityTreeSendThread::startNewTraversal(const ViewFrustum& view, EntityTree
                             // See the DiffTraversal::First case for an explanation of the "entity is too small" check
                             float renderAccuracy = calculateRenderAccuracy(_traversal.getCurrentView().getPosition(),
                                                                            cube,
-                                                                           octreeSizeScale,
+                                                                           _traversal.getCurrentRootSizeScale(),
                                                                            lodLevelOffset);
 
                             // Only send entities if they are large enough to see
@@ -271,7 +271,7 @@ void EntityTreeSendThread::startNewTraversal(const ViewFrustum& view, EntityTree
                                     // If this entity was skipped last time because it was too small, we still need to send it
                                     float lastRenderAccuracy = calculateRenderAccuracy(_traversal.getCompletedView().getPosition(),
                                                                                        cube,
-                                                                                       octreeSizeScale,
+                                                                                        _traversal.getCompletedRootSizeScale(),
                                                                                        lodLevelOffset);
 
                                     if (lastRenderAccuracy <= 0.0f) {

--- a/assignment-client/src/entities/EntityTreeSendThread.cpp
+++ b/assignment-client/src/entities/EntityTreeSendThread.cpp
@@ -197,24 +197,14 @@ void EntityTreeSendThread::startNewTraversal(const ViewFrustum& view, EntityTree
                         // larger octree cell because of its position (for example if it crosses the boundary of a cell it
                         // pops to the next higher cell. So we want to check to see that the entity is large enough to be seen
                         // before we consider including it.
-                        // We can't cull a parent-entity by its dimensions because the child may be larger.  We need to
-                        // avoid sending details about a child but not the parent.  The parent's queryAACube should have
-                        // been adjusted to encompass the queryAACube of the child.
-                        AABox entityBounds = entity->hasChildren() ? AABox(cube) : entity->getAABox(success);
-                        if (!success) {
-                            // if this entity is a child of an avatar, the entity-server wont be able to determine its
-                            // AABox.  If this happens, fall back to the queryAACube.
-                            entityBounds = AABox(cube);
-                        }
-
                         float renderAccuracy = calculateRenderAccuracy(_traversal.getCurrentView().getPosition(),
-                                                                       entityBounds,
+                                                                       cube,
                                                                        octreeSizeScale,
                                                                        lodLevelOffset);
 
                         // Only send entities if they are large enough to see
                         if (renderAccuracy > 0.0f) {
-                            float priority = _conicalView.computePriority(entityBounds);
+                            float priority = _conicalView.computePriority(cube);
                             _sendQueue.push(PrioritizedEntity(entity, priority));
                         }
                     }
@@ -236,19 +226,14 @@ void EntityTreeSendThread::startNewTraversal(const ViewFrustum& view, EntityTree
                         if (success) {
                             if (next.intersection == ViewFrustum::INSIDE || _traversal.getCurrentView().cubeIntersectsKeyhole(cube)) {
                                 // See the DiffTraversal::First case for an explanation of the "entity is too small" check
-                                AABox entityBounds = entity->hasChildren() ? AABox(cube) : entity->getAABox(success);
-                                if (!success) {
-                                    entityBounds = AABox(cube);
-                                }
-
                                 float renderAccuracy = calculateRenderAccuracy(_traversal.getCurrentView().getPosition(),
-                                                                               entityBounds,
+                                                                               cube,
                                                                                octreeSizeScale,
                                                                                lodLevelOffset);
 
                                 // Only send entities if they are large enough to see
                                 if (renderAccuracy > 0.0f) {
-                                    float priority = _conicalView.computePriority(entityBounds);
+                                    float priority = _conicalView.computePriority(cube);
                                     _sendQueue.push(PrioritizedEntity(entity, priority));
                                 }
                             }
@@ -272,30 +257,25 @@ void EntityTreeSendThread::startNewTraversal(const ViewFrustum& view, EntityTree
                     if (success) {
                         if (_traversal.getCurrentView().cubeIntersectsKeyhole(cube)) {
                             // See the DiffTraversal::First case for an explanation of the "entity is too small" check
-                            AABox entityBounds = entity->hasChildren() ? AABox(cube) : entity->getAABox(success);
-                            if (!success) {
-                                entityBounds = AABox(cube);
-                            }
-
                             float renderAccuracy = calculateRenderAccuracy(_traversal.getCurrentView().getPosition(),
-                                                                           entityBounds,
+                                                                           cube,
                                                                            octreeSizeScale,
                                                                            lodLevelOffset);
 
                             // Only send entities if they are large enough to see
                             if (renderAccuracy > 0.0f) {
                                 if (entity->getLastEdited() > timestamp || !_traversal.getCompletedView().cubeIntersectsKeyhole(cube)) {
-                                    float priority = _conicalView.computePriority(entityBounds);
+                                    float priority = _conicalView.computePriority(cube);
                                     _sendQueue.push(PrioritizedEntity(entity, priority));
                                 } else {
                                     // If this entity was skipped last time because it was too small, we still need to send it
                                     float lastRenderAccuracy = calculateRenderAccuracy(_traversal.getCompletedView().getPosition(),
-                                                                                       entityBounds,
+                                                                                       cube,
                                                                                        octreeSizeScale,
                                                                                        lodLevelOffset);
 
                                     if (lastRenderAccuracy <= 0.0f) {
-                                        float priority = _conicalView.computePriority(entityBounds);
+                                        float priority = _conicalView.computePriority(cube);
                                         _sendQueue.push(PrioritizedEntity(entity, priority));
                                     }
                                 }

--- a/assignment-client/src/entities/EntityTreeSendThread.h
+++ b/assignment-client/src/entities/EntityTreeSendThread.h
@@ -36,7 +36,7 @@ private:
     bool addAncestorsToExtraFlaggedEntities(const QUuid& filteredEntityID, EntityItem& entityItem, EntityNodeData& nodeData);
     bool addDescendantsToExtraFlaggedEntities(const QUuid& filteredEntityID, EntityItem& entityItem, EntityNodeData& nodeData);
 
-    void startNewTraversal(const ViewFrustum& viewFrustum, EntityTreeElementPointer root, int32_t lodLevelOffset);
+    void startNewTraversal(const ViewFrustum& viewFrustum, EntityTreeElementPointer root, float octreeSizeScale, int32_t lodLevelOffset);
 
     DiffTraversal _traversal;
     EntityPriorityQueue _sendQueue;

--- a/assignment-client/src/entities/EntityTreeSendThread.h
+++ b/assignment-client/src/entities/EntityTreeSendThread.h
@@ -36,7 +36,7 @@ private:
     bool addAncestorsToExtraFlaggedEntities(const QUuid& filteredEntityID, EntityItem& entityItem, EntityNodeData& nodeData);
     bool addDescendantsToExtraFlaggedEntities(const QUuid& filteredEntityID, EntityItem& entityItem, EntityNodeData& nodeData);
 
-    void startNewTraversal(const ViewFrustum& viewFrustum, EntityTreeElementPointer root, float octreeSizeScale, int32_t lodLevelOffset);
+    void startNewTraversal(const ViewFrustum& viewFrustum, EntityTreeElementPointer root, int32_t lodLevelOffset);
 
     DiffTraversal _traversal;
     EntityPriorityQueue _sendQueue;

--- a/libraries/entities/src/DiffTraversal.h
+++ b/libraries/entities/src/DiffTraversal.h
@@ -64,6 +64,9 @@ public:
     const ViewFrustum& getCurrentView() const { return _currentView.viewFrustum; }
     const ViewFrustum& getCompletedView() const { return _completedView.viewFrustum; }
 
+    const float getCurrentRootSizeScale() const { return _currentView.rootSizeScale; }
+    const float getCompletedRootSizeScale() const { return _completedView.rootSizeScale; }
+
     uint64_t getStartOfCompletedTraversal() const { return _completedView.startTime; }
     bool finished() const { return _path.empty(); }
 


### PR DESCRIPTION
Replicating the EntityTreeElement render accuracy check in EntityTreeSendThread::startNewTraversal()