### PR TITLE
fix bug that floods interface with updates

### DIFF
--- a/assignment-client/src/entities/EntityPriorityQueue.cpp
+++ b/assignment-client/src/entities/EntityPriorityQueue.cpp
@@ -11,7 +11,7 @@
 
 #include "EntityPriorityQueue.h"
 
-const float DO_NOT_SEND = -1.0e-6f;
+const float PrioritizedEntity::DO_NOT_SEND = -1.0e-6f;
 
 void ConicalView::set(const ViewFrustum& viewFrustum) {
     // The ConicalView has two parts: a central sphere (same as ViewFrustum) and a circular cone that bounds the frustum part.
@@ -47,7 +47,7 @@ float ConicalView::computePriority(const AACube& cube) const {
         const float AVOID_DIVIDE_BY_ZERO = 0.001f;
         return r / (d + AVOID_DIVIDE_BY_ZERO);
     }
-    return DO_NOT_SEND;
+    return PrioritizedEntity::DO_NOT_SEND;
 }
 
 // static
@@ -68,7 +68,7 @@ float PrioritizedEntity::updatePriority(const ConicalView& conicalView) {
     if (entity) {
         _priority = conicalView.computePriority(entity);
     } else {
-        _priority = DO_NOT_SEND;
+        _priority = PrioritizedEntity::DO_NOT_SEND;
     }
     return _priority;
 }

--- a/assignment-client/src/entities/EntityPriorityQueue.h
+++ b/assignment-client/src/entities/EntityPriorityQueue.h
@@ -39,6 +39,8 @@ private:
 // PrioritizedEntity is a placeholder in a sorted queue.
 class PrioritizedEntity {
 public:
+    static const float DO_NOT_SEND;
+
     PrioritizedEntity(EntityItemPointer entity, float priority) : _weakEntity(entity), _rawEntityPointer(entity.get()), _priority(priority) {}
     float updatePriority(const ConicalView& view);
     EntityItemPointer getEntity() const { return _weakEntity.lock(); }


### PR DESCRIPTION
We were deciding to start a repeat traversal when the view hadn't changed but we weren't yet finished with the current traversal.