### PR TITLE
Add state to entity tree send thread

### DIFF
--- a/assignment-client/src/entities/EntityPriorityQueue.cpp
+++ b/assignment-client/src/entities/EntityPriorityQueue.cpp
@@ -12,6 +12,7 @@
 #include "EntityPriorityQueue.h"
 
 const float PrioritizedEntity::DO_NOT_SEND = -1.0e-6f;
+const float PrioritizedEntity::WHEN_IN_DOUBT_PRIORITY = 1.0f;
 
 void ConicalView::set(const ViewFrustum& viewFrustum) {
     // The ConicalView has two parts: a central sphere (same as ViewFrustum) and a circular cone that bounds the frustum part.

--- a/assignment-client/src/entities/EntityPriorityQueue.h
+++ b/assignment-client/src/entities/EntityPriorityQueue.h
@@ -40,12 +40,14 @@ private:
 class PrioritizedEntity {
 public:
     static const float DO_NOT_SEND;
+    static const float WHEN_IN_DOUBT_PRIORITY;
 
-    PrioritizedEntity(EntityItemPointer entity, float priority) : _weakEntity(entity), _rawEntityPointer(entity.get()), _priority(priority) {}
+    PrioritizedEntity(EntityItemPointer entity, float priority, bool forceSend = false) : _weakEntity(entity), _rawEntityPointer(entity.get()), _priority(priority), _forceSend(forceSend) {}
     float updatePriority(const ConicalView& view);
     EntityItemPointer getEntity() const { return _weakEntity.lock(); }
     EntityItem* getRawEntityPointer() const { return _rawEntityPointer; }
     float getPriority() const { return _priority; }
+    bool shouldForceSend() const { return _forceSend; }
 
     class Compare {
     public:
@@ -57,6 +59,7 @@ private:
     EntityItemWeakPointer _weakEntity;
     EntityItem* _rawEntityPointer;
     float _priority;
+    bool _forceSend;
 };
 
 using EntityPriorityQueue = std::priority_queue< PrioritizedEntity, std::vector<PrioritizedEntity>, PrioritizedEntity::Compare >;

--- a/assignment-client/src/entities/EntityTreeSendThread.h
+++ b/assignment-client/src/entities/EntityTreeSendThread.h
@@ -24,9 +24,10 @@ class EntityNodeData;
 class EntityItem;
 
 class EntityTreeSendThread : public OctreeSendThread {
+    Q_OBJECT
 
 public:
-    EntityTreeSendThread(OctreeServer* myServer, const SharedNodePointer& node) : OctreeSendThread(myServer, node) { }
+    EntityTreeSendThread(OctreeServer* myServer, const SharedNodePointer& node);
 
 protected:
     void preDistributionProcessing() override;
@@ -44,12 +45,16 @@ private:
     DiffTraversal _traversal;
     EntityPriorityQueue _sendQueue;
     std::unordered_set<EntityItem*> _entitiesInQueue;
+    std::unordered_map<EntityItem*, uint64_t> _knownState;
     ConicalView _conicalView; // cached optimized view for fast priority calculations
 
     // packet construction stuff
     EntityTreeElementExtraEncodeDataPointer _extraEncodeData { new EntityTreeElementExtraEncodeData() };
     int32_t _numEntitiesOffset { 0 };
     uint16_t _numEntities { 0 };
+
+private slots:
+    void deletingEntityPointer(EntityItem* entity);
 };
 
 #endif // hifi_EntityTreeSendThread_h

--- a/assignment-client/src/entities/EntityTreeSendThread.h
+++ b/assignment-client/src/entities/EntityTreeSendThread.h
@@ -54,6 +54,7 @@ private:
     uint16_t _numEntities { 0 };
 
 private slots:
+    void editingEntityPointer(const EntityItemPointer entity);
     void deletingEntityPointer(EntityItem* entity);
 };
 

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -32,7 +32,8 @@
 #include "EntitySimulation.h"
 #include "EntityDynamicFactoryInterface.h"
 
-
+Q_DECLARE_METATYPE(EntityItemPointer);
+int entityItemPointernMetaTypeId = qRegisterMetaType<EntityItemPointer>();
 int EntityItem::_maxActionsDataSize = 800;
 quint64 EntityItem::_rememberDeletedActionTime = 20 * USECS_PER_SECOND;
 

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -62,7 +62,8 @@ class MeshProxyList;
 /// EntityItem class this is the base class for all entity types. It handles the basic properties and functionality available
 /// to all other entity types. In particular: postion, size, rotation, age, lifetime, velocity, gravity. You can not instantiate
 /// one directly, instead you must only construct one of it's derived classes with additional features.
-class EntityItem : public SpatiallyNestable, public ReadWriteLockable {
+class EntityItem : public QObject, public SpatiallyNestable, public ReadWriteLockable {
+    Q_OBJECT
     // These two classes manage lists of EntityItem pointers and must be able to cleanup pointers when an EntityItem is deleted.
     // To make the cleanup robust each EntityItem has backpointers to its manager classes (which are only ever set/cleared by
     // the managers themselves, hence they are fiends) whose NULL status can be used to determine which managers still need to

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -556,6 +556,7 @@ void EntityTree::deleteEntity(const EntityItemID& entityID, bool force, bool ign
 
     unhookChildAvatar(entityID);
     emit deletingEntity(entityID);
+    emit deletingEntityPointer(existingEntity.get());
 
     // NOTE: callers must lock the tree before using this method
     DeleteEntityOperator theOperator(getThisPointer(), entityID);
@@ -564,6 +565,10 @@ void EntityTree::deleteEntity(const EntityItemID& entityID, bool force, bool ign
         auto descendantID = descendant->getID();
         theOperator.addEntityIDToDeleteList(descendantID);
         emit deletingEntity(descendantID);
+        EntityItemPointer descendantEntity = std::static_pointer_cast<EntityItem>(descendant);
+        if (descendantEntity) {
+            emit deletingEntityPointer(descendantEntity.get());
+        }
     });
 
     recurseTreeWithOperator(&theOperator);
@@ -613,6 +618,7 @@ void EntityTree::deleteEntities(QSet<EntityItemID> entityIDs, bool force, bool i
         unhookChildAvatar(entityID);
         theOperator.addEntityIDToDeleteList(entityID);
         emit deletingEntity(entityID);
+        emit deletingEntityPointer(existingEntity.get());
     }
 
     if (theOperator.getEntities().size() > 0) {

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -307,7 +307,9 @@ bool EntityTree::updateEntity(EntityItemPointer entity, const EntityItemProperti
                 }
                 UpdateEntityOperator theOperator(getThisPointer(), containingElement, entity, queryCube);
                 recurseTreeWithOperator(&theOperator);
-                entity->setProperties(tempProperties);
+                if (entity->setProperties(tempProperties)) {
+                    emit editingEntityPointer(entity);
+                }
                 _isDirty = true;
             }
         }
@@ -382,7 +384,9 @@ bool EntityTree::updateEntity(EntityItemPointer entity, const EntityItemProperti
         }
         UpdateEntityOperator theOperator(getThisPointer(), containingElement, entity, newQueryAACube);
         recurseTreeWithOperator(&theOperator);
-        entity->setProperties(properties);
+        if (entity->setProperties(properties)) {
+            emit editingEntityPointer(entity);
+        }
 
         // if the entity has children, run UpdateEntityOperator on them.  If the children have children, recurse
         QQueue<SpatiallyNestablePointer> toProcess;
@@ -1255,7 +1259,7 @@ int EntityTree::processEditPacketData(ReceivedMessage& message, const unsigned c
                     if (!isPhysics) {
                         properties.setLastEditedBy(senderNode->getUUID());
                     }
-                    updateEntity(entityItemID, properties, senderNode);
+                    updateEntity(existingEntity, properties, senderNode);
                     existingEntity->markAsChangedOnServer();
                     endUpdate = usecTimestampNow();
                     _totalUpdates++;

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -270,6 +270,7 @@ signals:
     void deletingEntity(const EntityItemID& entityID);
     void deletingEntityPointer(EntityItem* entityID);
     void addingEntity(const EntityItemID& entityID);
+    void editingEntityPointer(const EntityItemPointer& entityID);
     void entityScriptChanging(const EntityItemID& entityItemID, const bool reload);
     void entityServerScriptChanging(const EntityItemID& entityItemID, const bool reload);
     void newCollisionSoundURL(const QUrl& url, const EntityItemID& entityID);

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -268,6 +268,7 @@ public:
 
 signals:
     void deletingEntity(const EntityItemID& entityID);
+    void deletingEntityPointer(EntityItem* entityID);
     void addingEntity(const EntityItemID& entityID);
     void entityScriptChanging(const EntityItemID& entityItemID, const bool reload);
     void entityServerScriptChanging(const EntityItemID& entityItemID, const bool reload);


### PR DESCRIPTION
The entity tree send thread keeps track of the last time it updated each entity.  Instead of comparing to last completed traversal time, we can now compare to this time.  Thus, in a scene of static entities, each entity will only ever need to be sent once.

Also: connects deletes and edits to signals in the EntityTreeSendThread so we can properly update entities.  As a trade-off, out of view entities are updated when edited.