### PR TITLE
Full scene traversal and JSON filters

### DIFF
--- a/assignment-client/src/entities/EntityTreeSendThread.h
+++ b/assignment-client/src/entities/EntityTreeSendThread.h
@@ -39,8 +39,8 @@ private:
     bool addAncestorsToExtraFlaggedEntities(const QUuid& filteredEntityID, EntityItem& entityItem, EntityNodeData& nodeData);
     bool addDescendantsToExtraFlaggedEntities(const QUuid& filteredEntityID, EntityItem& entityItem, EntityNodeData& nodeData);
 
-    void startNewTraversal(const ViewFrustum& viewFrustum, EntityTreeElementPointer root, int32_t lodLevelOffset);
-    bool traverseTreeAndBuildNextPacketPayload(EncodeBitstreamParams& params) override;
+    void startNewTraversal(const ViewFrustum& viewFrustum, EntityTreeElementPointer root, int32_t lodLevelOffset, bool usesFrustum);
+    bool traverseTreeAndBuildNextPacketPayload(EncodeBitstreamParams& params, const QJsonObject& jsonFilters) override;
 
     DiffTraversal _traversal;
     EntityPriorityQueue _sendQueue;

--- a/assignment-client/src/octree/OctreeSendThread.cpp
+++ b/assignment-client/src/octree/OctreeSendThread.cpp
@@ -458,7 +458,7 @@ int OctreeSendThread::packetDistributor(SharedNodePointer node, OctreeQueryNode*
     return _truePacketsSent;
 }
 
-bool OctreeSendThread::traverseTreeAndBuildNextPacketPayload(EncodeBitstreamParams& params) {
+bool OctreeSendThread::traverseTreeAndBuildNextPacketPayload(EncodeBitstreamParams& params, const QJsonObject& jsonFilters) {
     bool somethingToSend = false;
     OctreeQueryNode* nodeData = static_cast<OctreeQueryNode*>(params.nodeData);
     if (!nodeData->elementBag.isEmpty()) {
@@ -523,7 +523,7 @@ void OctreeSendThread::traverseTreeAndSendContents(SharedNodePointer node, Octre
         bool lastNodeDidntFit = false; // assume each node fits
         params.stopReason = EncodeBitstreamParams::UNKNOWN; // reset params.stopReason before traversal
 
-        somethingToSend = traverseTreeAndBuildNextPacketPayload(params);
+        somethingToSend = traverseTreeAndBuildNextPacketPayload(params, nodeData->getJSONParameters());
 
         // If the bag had contents but is now empty then we know we've sent the entire scene.
         bool completedScene = bagHadSomething && nodeData->elementBag.isEmpty();

--- a/assignment-client/src/octree/OctreeSendThread.h
+++ b/assignment-client/src/octree/OctreeSendThread.h
@@ -55,7 +55,7 @@ protected:
     virtual void preDistributionProcessing() {};
     virtual void traverseTreeAndSendContents(SharedNodePointer node, OctreeQueryNode* nodeData,
             bool viewFrustumChanged, bool isFullScene);
-    virtual bool traverseTreeAndBuildNextPacketPayload(EncodeBitstreamParams& params);
+    virtual bool traverseTreeAndBuildNextPacketPayload(EncodeBitstreamParams& params, const QJsonObject& jsonFilters);
 
     OctreePacketData _packetData;
     QWeakPointer<Node> _node;

--- a/libraries/entities/src/DiffTraversal.h
+++ b/libraries/entities/src/DiffTraversal.h
@@ -46,6 +46,7 @@ public:
         void getNextVisibleElementFirstTime(VisibleElement& next, const View& view);
         void getNextVisibleElementRepeat(VisibleElement& next, const View& view, uint64_t lastTime);
         void getNextVisibleElementDifferential(VisibleElement& next, const View& view, const View& lastView);
+        void getNextVisibleElementFullScene(VisibleElement& next, uint64_t lastTime);
 
         int8_t getNextIndex() const { return _nextIndex; }
         void initRootNextIndex() { _nextIndex = -1; }
@@ -55,11 +56,11 @@ public:
         int8_t _nextIndex;
     };
 
-    typedef enum { First, Repeat, Differential } Type;
+    typedef enum { First, Repeat, Differential, FullScene } Type;
 
     DiffTraversal();
 
-    Type prepareNewTraversal(const ViewFrustum& viewFrustum, EntityTreeElementPointer root, int32_t lodLevelOffset);
+    Type prepareNewTraversal(const ViewFrustum& viewFrustum, EntityTreeElementPointer root, int32_t lodLevelOffset, bool isFullScene);
 
     const ViewFrustum& getCurrentView() const { return _currentView.viewFrustum; }
     const ViewFrustum& getCompletedView() const { return _completedView.viewFrustum; }


### PR DESCRIPTION
The Entity Script Server doesn't use a view frustum and only queries entities with non-default serverScripts properties, so we need a new type of traversal/scan

Things to consider:
- we are ignoring isFullScene, but it might contain useful information (haveJSONParametersChanged)
- move JSON filter check into the scan callbacks so _sendQueue isn't full of things that are going to be eliminated later