### PR TITLE
Edited entities are not repeatedly sent if out of view

### DIFF
--- a/assignment-client/src/entities/EntityPriorityQueue.cpp
+++ b/assignment-client/src/entities/EntityPriorityQueue.cpp
@@ -12,6 +12,7 @@
 #include "EntityPriorityQueue.h"
 
 const float PrioritizedEntity::DO_NOT_SEND = -1.0e-6f;
+const float PrioritizedEntity::FORCE_REMOVE = -1.0e-5f;
 const float PrioritizedEntity::WHEN_IN_DOUBT_PRIORITY = 1.0f;
 
 void ConicalView::set(const ViewFrustum& viewFrustum) {

--- a/assignment-client/src/entities/EntityPriorityQueue.h
+++ b/assignment-client/src/entities/EntityPriorityQueue.h
@@ -40,14 +40,15 @@ private:
 class PrioritizedEntity {
 public:
     static const float DO_NOT_SEND;
+    static const float FORCE_REMOVE;
     static const float WHEN_IN_DOUBT_PRIORITY;
 
-    PrioritizedEntity(EntityItemPointer entity, float priority, bool forceSend = false) : _weakEntity(entity), _rawEntityPointer(entity.get()), _priority(priority), _forceSend(forceSend) {}
+    PrioritizedEntity(EntityItemPointer entity, float priority, bool forceRemove = false) : _weakEntity(entity), _rawEntityPointer(entity.get()), _priority(priority), _forceRemove(forceRemove) {}
     float updatePriority(const ConicalView& view);
     EntityItemPointer getEntity() const { return _weakEntity.lock(); }
     EntityItem* getRawEntityPointer() const { return _rawEntityPointer; }
     float getPriority() const { return _priority; }
-    bool shouldForceSend() const { return _forceSend; }
+    bool shouldForceRemove() const { return _forceRemove; }
 
     class Compare {
     public:
@@ -59,7 +60,7 @@ private:
     EntityItemWeakPointer _weakEntity;
     EntityItem* _rawEntityPointer;
     float _priority;
-    bool _forceSend;
+    bool _forceRemove;
 };
 
 using EntityPriorityQueue = std::priority_queue< PrioritizedEntity, std::vector<PrioritizedEntity>, PrioritizedEntity::Compare >;

--- a/assignment-client/src/entities/EntityTreeSendThread.h
+++ b/assignment-client/src/entities/EntityTreeSendThread.h
@@ -39,7 +39,7 @@ private:
     bool addAncestorsToExtraFlaggedEntities(const QUuid& filteredEntityID, EntityItem& entityItem, EntityNodeData& nodeData);
     bool addDescendantsToExtraFlaggedEntities(const QUuid& filteredEntityID, EntityItem& entityItem, EntityNodeData& nodeData);
 
-    void startNewTraversal(const ViewFrustum& viewFrustum, EntityTreeElementPointer root, int32_t lodLevelOffset, bool usesFrustum);
+    void startNewTraversal(const ViewFrustum& viewFrustum, EntityTreeElementPointer root, int32_t lodLevelOffset, bool usesViewFrustum);
     bool traverseTreeAndBuildNextPacketPayload(EncodeBitstreamParams& params, const QJsonObject& jsonFilters) override;
 
     DiffTraversal _traversal;

--- a/libraries/entities/src/DiffTraversal.h
+++ b/libraries/entities/src/DiffTraversal.h
@@ -36,6 +36,7 @@ public:
         uint64_t startTime { 0 };
         float rootSizeScale { 1.0f };
         int32_t lodLevelOffset { 0 };
+        bool usesViewFrustum { true };
     };
 
     // Waypoint is an bookmark in a "path" of waypoints during a traversal.
@@ -46,7 +47,6 @@ public:
         void getNextVisibleElementFirstTime(VisibleElement& next, const View& view);
         void getNextVisibleElementRepeat(VisibleElement& next, const View& view, uint64_t lastTime);
         void getNextVisibleElementDifferential(VisibleElement& next, const View& view, const View& lastView);
-        void getNextVisibleElementFullScene(VisibleElement& next, uint64_t lastTime);
 
         int8_t getNextIndex() const { return _nextIndex; }
         void initRootNextIndex() { _nextIndex = -1; }
@@ -56,15 +56,16 @@ public:
         int8_t _nextIndex;
     };
 
-    typedef enum { First, Repeat, Differential, FullScene } Type;
+    typedef enum { First, Repeat, Differential } Type;
 
     DiffTraversal();
 
-    Type prepareNewTraversal(const ViewFrustum& viewFrustum, EntityTreeElementPointer root, int32_t lodLevelOffset, bool isFullScene);
+    Type prepareNewTraversal(const ViewFrustum& viewFrustum, EntityTreeElementPointer root, int32_t lodLevelOffset, bool usesViewFrustum);
 
     const ViewFrustum& getCurrentView() const { return _currentView.viewFrustum; }
     const ViewFrustum& getCompletedView() const { return _completedView.viewFrustum; }
 
+    bool doesCurrentUseViewFrustum() const { return _currentView.usesViewFrustum; }
     float getCurrentRootSizeScale() const { return _currentView.rootSizeScale; }
     float getCompletedRootSizeScale() const { return _completedView.rootSizeScale; }
     float getCurrentLODOffset() const { return _currentView.lodLevelOffset; }

--- a/libraries/shared/src/ViewFrustum.cpp
+++ b/libraries/shared/src/ViewFrustum.cpp
@@ -403,12 +403,12 @@ bool ViewFrustum::isVerySimilar(const ViewFrustum& compareTo, bool debug) const 
     bool result =
         testMatches(0, positionDistance, POSITION_SIMILAR_ENOUGH) &&
         testMatches(0, angleOrientation, ORIENTATION_SIMILAR_ENOUGH) &&
-           testMatches(compareTo._fieldOfView, _fieldOfView) &&
-           testMatches(compareTo._aspectRatio, _aspectRatio) &&
-           testMatches(compareTo._nearClip, _nearClip) &&
-           testMatches(compareTo._farClip, _farClip) &&
-           testMatches(compareTo._focalLength, _focalLength);
-
+        testMatches(compareTo._centerSphereRadius, _centerSphereRadius) &&
+        testMatches(compareTo._fieldOfView, _fieldOfView) &&
+        testMatches(compareTo._aspectRatio, _aspectRatio) &&
+        testMatches(compareTo._nearClip, _nearClip) &&
+        testMatches(compareTo._farClip, _farClip) &&
+        testMatches(compareTo._focalLength, _focalLength);
 
     if (!result && debug) {
         qCDebug(shared, "ViewFrustum::isVerySimilar()... result=%s\n", debug::valueOf(result));


### PR DESCRIPTION
Also handles cases where usesViewFrustum changes, and reduces number of lookups in _knownState.