### PR TITLE
Small fixes and LOD cull children instead of parent

### DIFF
--- a/assignment-client/src/entities/EntityTreeSendThread.cpp
+++ b/assignment-client/src/entities/EntityTreeSendThread.cpp
@@ -121,7 +121,7 @@ void EntityTreeSendThread::traverseTreeAndSendContents(SharedNodePointer node, O
                                     float renderAccuracy = calculateRenderAccuracy(_traversal.getCurrentView().getPosition(),
                                                                                    cube,
                                                                                    _traversal.getCurrentRootSizeScale(),
-                                                                                   lodLevelOffset);
+                                                                                   _traversal.getCurrentLODOffset());
 
                                     // Only send entities if they are large enough to see
                                     if (renderAccuracy > 0.0f) {
@@ -385,12 +385,12 @@ void EntityTreeSendThread::startNewTraversal(const ViewFrustum& view, EntityTree
                                         _entitiesInQueue.insert(entity.get());
                                     } else {
                                         // If this entity was skipped last time because it was too small, we still need to send it
-                                        float lastRenderAccuracy = calculateRenderAccuracy(_traversal.getCompletedView().getPosition(),
-                                                                                           cube,
-                                                                                           _traversal.getCompletedRootSizeScale(),
-                                                                                           _traversal.getCompletedLODOffset());
+                                        renderAccuracy = calculateRenderAccuracy(_traversal.getCompletedView().getPosition(),
+                                                                                 cube,
+                                                                                 _traversal.getCompletedRootSizeScale(),
+                                                                                 _traversal.getCompletedLODOffset());
 
-                                        if (lastRenderAccuracy <= 0.0f) {
+                                        if (renderAccuracy <= 0.0f) {
                                             float priority = _conicalView.computePriority(cube);
                                             _sendQueue.push(PrioritizedEntity(entity, priority));
                                             _entitiesInQueue.insert(entity.get());

--- a/libraries/entities/src/DiffTraversal.h
+++ b/libraries/entities/src/DiffTraversal.h
@@ -68,8 +68,8 @@ public:
     bool doesCurrentUseViewFrustum() const { return _currentView.usesViewFrustum; }
     float getCurrentRootSizeScale() const { return _currentView.rootSizeScale; }
     float getCompletedRootSizeScale() const { return _completedView.rootSizeScale; }
-    float getCurrentLODOffset() const { return _currentView.lodLevelOffset; }
-    float getCompletedLODOffset() const { return _completedView.lodLevelOffset; }
+    int32_t getCurrentLODOffset() const { return _currentView.lodLevelOffset; }
+    int32_t getCompletedLODOffset() const { return _completedView.lodLevelOffset; }
 
     uint64_t getStartOfCompletedTraversal() const { return _completedView.startTime; }
     bool finished() const { return _path.empty(); }


### PR DESCRIPTION
Also use calculateRenderAccuracy to be consistent with entity LOD culling